### PR TITLE
vesa.c: Do not check for attached drivers on DFBSD & FBSD

### DIFF
--- a/src/vesa.c
+++ b/src/vesa.c
@@ -479,10 +479,15 @@ VESAPciProbe(DriverPtr drv, int entity_num, struct pci_device *dev,
     if (pScrn != NULL) {
 	VESAPtr pVesa;
 
+#if !defined (__FreeBSD__) && !defined (__DragonFly__)
 	if (pci_device_has_kernel_driver(dev)) {
 	    ErrorF("vesa: Ignoring device with a bound kernel driver\n");
 	    return FALSE;
 	}
+#else
+	xf86DrvMsg(-1,X_WARNING,"vesa: Not checking for attached KMS drivers on FreeBSD and DragonFlyBSD.\n\
+			Using this driver with a kernel KMS driver loaded can cause a blackscreen!\n");
+#endif
 
 	pVesa = VESAGetRec(pScrn);
 	VESAInitScrn(pScrn);


### PR DESCRIPTION
On both DragonFlyBSD and FreeBSD the vgapci driver is always attach to the device, so we should not dismiss devices based on attached drivers on these platforms.

Related patches:
https://github.com/freebsd/freebsd-ports/commit/b6d89731d542582d2cc751e7a56b78df76a38ce7
https://github.com/DragonFlyBSD/DeltaPorts/commit/7e57b5bb9ba5e5f7227307cbffb3e66226e29377